### PR TITLE
updates for ocp 4.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,44 @@ Wireguard Kernel Module installed and managed via KMMO / Driver Toolkit. Read mo
           value: "https://git.zx2c4.com/wireguard-linux-compat/snapshot"
 ```
 
+### Configure FelixConfiguration resource for each control plane node
+
+Wireguard encryption should not be enabled for the OCP control plane nodes (a.k.a. master nodes). Configure control plane node specific `FelixConfiguration` resources to disable Wireguard encryption for those nodes.
+
+```bash
+# example config
+cat <<EOF | oc apply -f-
+apiVersion: projectcalico.org/v3
+kind: FelixConfiguration
+metadata:
+  name: node.<NODE_NAME>
+spec:
+  logSeverityScreen: Info
+  reportingInterval: 0s
+  wireguardEnabled: false
+  wireguardEnabledV6: false
+EOF
+```
+
+An example script to configure the `FelixConfiguration` resource for each control plane node.
+
+```bash
+MASTER_NAMES=($(kubectl get nodes -l node-role.kubernetes.io/master= -ojsonpath='{.items[*].metadata.name}'))
+for name in ${MASTER_NAMES[@]};do
+  cat <<EOF | oc apply -f-
+  apiVersion: projectcalico.org/v3
+  kind: FelixConfiguration
+  metadata:
+    name: node.$name
+  spec:
+    logSeverityScreen: Info
+    reportingInterval: 0s
+    wireguardEnabled: false
+    wireguardEnabledV6: false
+EOF
+done
+```
+
 ### Example output
 
 ```text

--- a/manifests/01-wireguard-kmmo.yaml
+++ b/manifests/01-wireguard-kmmo.yaml
@@ -31,7 +31,7 @@ spec:
     - configMap:
         name: wireguard-kmod-helpers
     dockerfile: |
-      FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:0661d0560654e7e2d1761e883ffdd6c482c8c8f37e60608bb59c44fa81a3f0bb
+      FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:397bdb1550d3d620376760449a14147266e87a5486a85e1381b10052daa0b392
 
       ARG ARTIFACTS_LOCATION
       ARG WIREGUARD_ARCHIVE_NAME
@@ -39,7 +39,7 @@ spec:
 
 
       WORKDIR /
-      RUN cat /etc/systemd/system/kmod*
+      #RUN cat /etc/systemd/system/kmod*
       RUN echo "Downloading ${ARTIFACTS_LOCATION}/${WIREGUARD_ARCHIVE_NAME}.tar.xz (${WIREGUARD_ARCHIVE_SHA256})" &&            \
         curl -LS ${ARTIFACTS_LOCATION}/${WIREGUARD_ARCHIVE_NAME}.tar.xz |                                                       \
         { t="$(mktemp)"; trap "rm -f '$t'" INT TERM EXIT; cat >| "$t"; sha256sum --quiet -c <<<"${WIREGUARD_ARCHIVE_SHA256} $t" \
@@ -65,9 +65,9 @@ spec:
     dockerStrategy:
       buildArgs:
         - name: WIREGUARD_ARCHIVE_NAME
-          value: "wireguard-linux-compat-1.0.20210606"
+          value: "wireguard-linux-compat-1.0.20220627"
         - name: WIREGUARD_ARCHIVE_SHA256
-          value: "3f5d990006e6eabfd692d925ec314fff2c5ee7dcdb869a6510d579acfdd84ec0"
+          value: "362d412693c8fe82de00283435818d5c5def7f15e2433a07a9fe99d0518f63c0"
         - name: ARTIFACTS_LOCATION
           value: "https://git.zx2c4.com/wireguard-linux-compat/snapshot"
   output:

--- a/manifests/01-wireguard-kmmo.yaml
+++ b/manifests/01-wireguard-kmmo.yaml
@@ -39,7 +39,6 @@ spec:
 
 
       WORKDIR /
-      #RUN cat /etc/systemd/system/kmod*
       RUN echo "Downloading ${ARTIFACTS_LOCATION}/${WIREGUARD_ARCHIVE_NAME}.tar.xz (${WIREGUARD_ARCHIVE_SHA256})" &&            \
         curl -LS ${ARTIFACTS_LOCATION}/${WIREGUARD_ARCHIVE_NAME}.tar.xz |                                                       \
         { t="$(mktemp)"; trap "rm -f '$t'" INT TERM EXIT; cat >| "$t"; sha256sum --quiet -c <<<"${WIREGUARD_ARCHIVE_SHA256} $t" \


### PR DESCRIPTION
## README updates

- added a one-liner command to determine the Image Registry Operator state in the **Prerequisites** section
- expanded step 2 in the **Queck start** section with more details how to update `BuildConfig` resource
- updated **BuildConfig buildArgs** section Wireguard related parameters

## `manifests/01-wireguard-kmmo.yaml` updates

- updated image for the `dockerfile` section with the one from OCP 4.11.30
- updated Wireguard related params at the `strategy.dockerStrategy.buildArgs` section
- added section to configure FelixConfig for master nodes
